### PR TITLE
Adds DEBUGLOG to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ kernel
 kernelmemfs
 mkfs
 .gdbinit
+DEBUGLOG


### PR DESCRIPTION
Nit: the `DEBUGLOG` should be in gitignore