### PR TITLE
Added missing parens to BBLOCK

### DIFF
--- a/fs.h
+++ b/fs.h
@@ -44,7 +44,7 @@ struct dinode {
 #define BPB           (BSIZE*8)
 
 // Block of free map containing bit for block b
-#define BBLOCK(b, sb) (b/BPB + sb.bmapstart)
+#define BBLOCK(b, sb) ((b)/BPB + sb.bmapstart)
 
 // Directory is a file containing a sequence of dirent structures.
 #define DIRSIZ 14


### PR DESCRIPTION
Added parenthesis around the b in BBLOCK in order to stop order of operations from getting messed up after the macro is expanded.